### PR TITLE
AWS-SDK-PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.3.0",
         "irap/core-libs": "1.1.*",
-        "aws/aws-sdk-php" : "3.133.*",
+        "aws/aws-sdk-php" : "3.*",
         "ext-libxml" : "*",
         "ext-simplexml" : "*"
     },


### PR DESCRIPTION
Updated the required version for AWS-SDK-PHP to 3.* because bug fixes in v3 happen too fast to keep changing the minor-version.